### PR TITLE
Remove whitespace before semicolons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ os:
 go:
   - 1.4
   - 1.5
-  - tip
 
 install:
  - go get ./...

--- a/asmfmt.go
+++ b/asmfmt.go
@@ -539,6 +539,22 @@ func (st statement) define() string {
 	return ""
 }
 
+func splitSemic(s string) string {
+	split := strings.Split(s, ";")
+	for i := range split {
+		split[i] = strings.TrimSpace(split[i])
+	}
+	return strings.TrimSpace(strings.Join(split, "; "))
+}
+
+func (st *statement) cleanParams() {
+	// Remove whitespace before semicolons
+	for i := range st.params {
+		st.params[i] = splitSemic(st.params[i])
+	}
+	st.instruction = splitSemic(st.instruction)
+}
+
 // formatStatements will format a slice of statements and return each line
 // as a separate string.
 // Comments and line-continuation (\) are aligned with spaces.
@@ -549,6 +565,7 @@ func formatStatements(s []statement) []string {
 	maxAlone := 0 // Length of longest instruction without parameters.
 	maxComm := 0  // Lenght of longest end-of-line comment.
 	for _, x := range s {
+		x.cleanParams()
 		il := len([]rune(x.instruction)) + 1 // Instruction length
 		l := il
 		// Ignore length if we are a define "function"

--- a/testdata/bytes.golden
+++ b/testdata/bytes.golden
@@ -1,0 +1,6 @@
+	BYTE $0x48; BYTE $0x8d; BYTE $0x3d; BYTE $0xc9; BYTE $0x6a; BYTE $0xa3; BYTE $0x00
+	BYTE                                                                               // don't touch;semicolon in my comments
+
+#define macro \
+	NOP /* don't touch; semicolon in my comments*/ \
+	RET

--- a/testdata/bytes.golden
+++ b/testdata/bytes.golden
@@ -2,5 +2,5 @@
 	BYTE                                                                               // don't touch;semicolon in my comments
 
 #define macro \
-	NOP /* don't touch; semicolon in my comments*/ \
+	NOP /* don't touch;semicolon in my comments*/ \
 	RET

--- a/testdata/bytes.in
+++ b/testdata/bytes.in
@@ -1,0 +1,6 @@
+BYTE $0x48;BYTE $0x8d;BYTE $0x3d;BYTE $0xc9;BYTE $0x6a;BYTE $0xa3;BYTE $0x00
+BYTE /* don't touch;semicolon in my comments*/
+
+#define macro \
+ NOP /* don't touch;semicolon in my comments*/ \
+ RET

--- a/testdata/mod_math_amd64.golden
+++ b/testdata/mod_math_amd64.golden
@@ -50,20 +50,20 @@ TEXT ·mod_add(SB), 7, $0-24
 // This is much faster (2 or 3 times) than DIVQ
 #define MOD_REDUCE(b, a, t0, t1, p, label) \
 	MOVL        b, t0; /* Also sets upper 32 bits to 0 */ \
-	SHRQ        $32, b ;                                  \
+	SHRQ        $32, b;                                   \
 	;                                                     \
-	CMPQ        a, p ;                                    \
-	JCS         label/**/1 ;                              \
-	SUBQ        p, a ;                                    \
+	CMPQ        a, p;                                     \
+	JCS         label/**/1;                               \
+	SUBQ        p, a;                                     \
 	label/**/1: ;                                         \
 	;                                                     \
-	MOVLQZX     t0, t1 ;                                  \
+	MOVLQZX     t0, t1;                                   \
 	MOD_SUB(a, t1, p, label/**/2) ;                       \
 	;                                                     \
-	MOVLQZX     b, t1 ;                                   \
+	MOVLQZX     b, t1;                                    \
 	MOD_SUB(a, t1, p, label/**/3) ;                       \
 	;                                                     \
-	SHLQ        $32, t0 ;                                 \
+	SHLQ        $32, t0;                                  \
 	MOD_ADD(a, t0, t1, p, label/**/4) ;                   \
 
 TEXT ·mod_reduce(SB), 7, $0-24
@@ -98,7 +98,7 @@ TEXT ·mod_sqr(SB), 7, $0-16
 	/* xmid_xlow := x << shift, (xmid, xlow) */                                              \
 	SHLQ $shift, x;                                                                          \
 	/* xhigh := uint32(x >> (64 - shift)) */                                                 \
-	SHRQ $(64-shift), t0 ;                                                                   \
+	SHRQ $(64-shift), t0;                                                                    \
 	/* t := uint64(0xFFFFFFFF-xhigh)<<32 + uint64(xhigh+1), (2^32 - 1 - xhigh, xhigh + 1) */ \
 	MOVL t0, t1;                                                                             \
 	SHLQ $32, t0;                                                                            \

--- a/testdata/mod_math_arm.golden
+++ b/testdata/mod_math_arm.golden
@@ -177,12 +177,12 @@ TEXT ·mod_add(SB), 7, $0-24
 	SBC      $0, z2, z2  /* can't carry */;                                  \
 	                                                                         \
 	ADD.S    z3, z0, z0  /* (x1,x0) = (z1,z0)+(z2,z3) */;                    \
-	ADC.S    z2, z1, z1  ;                                                   \
+	ADC.S    z2, z1, z1;                                                     \
 	                                                                         \
 	/* CC = carry clear is borrow from subtract or no carry from add */;     \
 	                                                                         \
 	label:   SUB.CC.S neg1, z0, z0  /* if no carry (x1,x0) -= (0,2^32-1) */; \
-	SBC.CC.S $0, z1, z1  ;                                                   \
+	SBC.CC.S $0, z1, z1;                                                     \
 	                                                                         \
 	BCC      label   /* Sub again if borrow - infrequent */;                 \
 
@@ -222,12 +222,12 @@ TEXT ·mod_reduce(SB), 7, $0-24
 	MULLU y0, x1, (t0, y0) /* [not z0 or z1] */;                         \
 	MULLU y1, x1, (z3, z2) /* [not y0 or t0] */;                         \
 	ADD.S y0, z1, z1  /* [not z2 or z3] */;                              \
-	ADC.S t0, z2, z2  ;                                                  \
-	MULLU y1, x0, (t0, y0) ;                                             \
+	ADC.S t0, z2, z2;                                                    \
+	MULLU y1, x0, (t0, y0);                                              \
 	ADC   $0, z3, z3   /* [not y0 or t0] */;                             \
-	ADD.S y0, z1, z1  ;                                                  \
-	ADC.S t0, z2, z2  ;                                                  \
-	ADC   $0, z3, z3  ;                                                  \
+	ADD.S y0, z1, z1;                                                    \
+	ADC.S t0, z2, z2;                                                    \
+	ADC   $0, z3, z3;                                                    \
 	MOD_REDUCE(z0, z1, z2, z3, neg1, label) ;                            \
 
 // 4 words at 4..20(R13) for called routine parameters
@@ -261,16 +261,16 @@ TEXT ·mod_mul(SB), 7, $0-24
 // 64 x 64 -> 128 bit square - takes 18 cycles
 // (x1,x0) * (x1,x0) -> (z3, z2, z1, z0)
 #define MOD_SQR(z0, z1, x0, x1, z2, z3, t0, neg1, label) \
-	MULLU x0, x0, (z1, z0) /* odd order is to reduce pipeline stalls */ ; \
-	MULLU x0, x1, (t0, x0) /* [not z0 or z1] */ ;                         \
-	MULLU x1, x1, (z3, z2) /* [not x0 or t0] */ ;                         \
-	ADD.S x0, z1, z1 /* [not z2 or z3] */ ;                               \
-	ADC.S t0, z2, z2 ;                                                    \
-	ADC   $0, z3, z3 ;                                                    \
-	ADD.S x0, z1, z1 ;                                                    \
-	ADC.S t0, z2, z2 ;                                                    \
-	ADC   $0, z3, z3 ;                                                    \
-	MOD_REDUCE(z0, z1, z2, z3, neg1, label);                              \
+	MULLU x0, x0, (z1, z0) /* odd order is to reduce pipeline stalls */; \
+	MULLU x0, x1, (t0, x0) /* [not z0 or z1] */;                         \
+	MULLU x1, x1, (z3, z2) /* [not x0 or t0] */;                         \
+	ADD.S x0, z1, z1 /* [not z2 or z3] */;                               \
+	ADC.S t0, z2, z2;                                                    \
+	ADC   $0, z3, z3;                                                    \
+	ADD.S x0, z1, z1;                                                    \
+	ADC.S t0, z2, z2;                                                    \
+	ADC   $0, z3, z3;                                                    \
+	MOD_REDUCE(z0, z1, z2, z3, neg1, label);                             \
 
 // 2 words at 4..12(R13) for called routine parameters
 TEXT ·mod_sqr(SB), 7, $0-24
@@ -306,19 +306,19 @@ TEXT ·mod_sqr(SB), 7, $0-24
 	/* calculate (t1,t0) = (xhigh, xlow) - (2^32 - 1 - xhigh, xhigh + 1) */;                \
 	RSB.S    x0<<shift, t0, t0   /* xlow - t0 */;                                           \
 	MOVW     x1<<shift, x1     /* x1 = xmid */;                                             \
-	ORR      x0>>(32-shift), x1, x1   ;                                                     \
+	ORR      x0>>(32-shift), x1, x1;                                                        \
 	SBC.S    t1, x1, t1    /* xhigh - t1 - carry */;                                        \
-	SUB.CC.S neg1, t0, t0   ;                                                               \
-	SBC.CC   $0, t1, t1    ;                                                                \
+	SUB.CC.S neg1, t0, t0;                                                                  \
+	SBC.CC   $0, t1, t1;                                                                    \
 
 #define MOD_SHIFT_0_TO_31_PROC(shift) \
-	MOVW    $-1, R12 ;                                   \
-	MOVW    $0, R11 ;                                    \
-	MOVM.IB (R13), [R0, R1] ;                            \
-	MOD_SHIFT_0_TO_31(shift, R4, R5, R0, R1, R12, R11) ; \
-	MOVW    R4, ret+8(FP) ;                              \
-	MOVW    R5, ret+12(FP) ;                             \
-	RET     ;                                            \
+	MOVW    $-1, R12;                                   \
+	MOVW    $0, R11;                                    \
+	MOVM.IB (R13), [R0, R1];                            \
+	MOD_SHIFT_0_TO_31(shift, R4, R5, R0, R1, R12, R11) ;\
+	MOVW    R4, ret+8(FP);                              \
+	MOVW    R5, ret+12(FP);                             \
+	RET     ;                                           \
 
 TEXT ·mod_shift3(SB), 7, $0-16
 	MOD_SHIFT_0_TO_31_PROC(3)
@@ -376,29 +376,29 @@ TEXT ·mod_shift30(SB), 7, $0-16
 	// ------------------------------------------------------------
 
 #define MOD_SHIFT_32_TO_63(shift, t0, t1, x0, x1, neg1) \
-	/* xhigh = x1, LSR #64 - shift */  ;                                            \
-	/* xmid = (x1, LSL #shift - 32) OR (x0, LSR #64 - shift) */ ;                   \
-	/* xlow  = x0, LSL #shift - 32 */  ;                                            \
-	MOVW     x1<<(shift-32), t1   /* t1 = xmid */ ;                                 \
-	ORR      x0>>(64-shift), t1, t1    ;                                            \
-	/* calculate (t1,t0) = (-xmid, xhigh + xmid) */ ;                               \
-	RSB.S    $0, t1, t1    /* xmidneg = 0 - xmid */ ;                               \
-	SBC      $0, t1, t0    /* xmidcomp = xmidneg - (borrow from last subtract) */ ; \
-	RSB.S    x1>>(64-shift), t0, t0   /* xhigh - xmidcomp */ ;                      \
-	SBC      $0, t1, t1    /* xmidneg - carry */ ;                                  \
-	/* calculate (t1,t0) = (xlow, 0) - (t1,t0) mod p */ ;                           \
-	RSB.S    $0, t0, t0    /* 0 - t0 */ ;                                           \
-	RSC.S    x0<<(shift-32), t1, t1   /* xlow - t1 - carry */ ;                     \
-	SUB.CC.S neg1, t0, t0   ;                                                       \
-	SBC.CC   $0, t1, t1    ;                                                        \
+	/* xhigh = x1, LSR #64 - shift */  ;                                           \
+	/* xmid = (x1, LSL #shift - 32) OR (x0, LSR #64 - shift) */ ;                  \
+	/* xlow  = x0, LSL #shift - 32 */  ;                                           \
+	MOVW     x1<<(shift-32), t1   /* t1 = xmid */;                                 \
+	ORR      x0>>(64-shift), t1, t1;                                               \
+	/* calculate (t1,t0) = (-xmid, xhigh + xmid) */ ;                              \
+	RSB.S    $0, t1, t1    /* xmidneg = 0 - xmid */;                               \
+	SBC      $0, t1, t0    /* xmidcomp = xmidneg - (borrow from last subtract) */; \
+	RSB.S    x1>>(64-shift), t0, t0   /* xhigh - xmidcomp */;                      \
+	SBC      $0, t1, t1    /* xmidneg - carry */;                                  \
+	/* calculate (t1,t0) = (xlow, 0) - (t1,t0) mod p */ ;                          \
+	RSB.S    $0, t0, t0    /* 0 - t0 */;                                           \
+	RSC.S    x0<<(shift-32), t1, t1   /* xlow - t1 - carry */;                     \
+	SUB.CC.S neg1, t0, t0;                                                         \
+	SBC.CC   $0, t1, t1;                                                           \
 
 #define MOD_SHIFT_32_TO_63_PROC(shift) \
-	MOVW    $-1, R12 ;                               \
-	MOVM.IB (R13), [R0, R1] ;                        \
-	MOD_SHIFT_32_TO_63(shift, R4, R5, R0, R1, R12) ; \
-	MOVW    R4, ret+8(FP) ;                          \
-	MOVW    R5, ret+12(FP) ;                         \
-	RET     ;                                        \
+	MOVW    $-1, R12;                               \
+	MOVM.IB (R13), [R0, R1];                        \
+	MOD_SHIFT_32_TO_63(shift, R4, R5, R0, R1, R12) ;\
+	MOVW    R4, ret+8(FP);                          \
+	MOVW    R5, ret+12(FP);                         \
+	RET     ;                                       \
 
 TEXT ·mod_shift33(SB), 7, $0-16
 	MOD_SHIFT_32_TO_63_PROC(33)
@@ -446,28 +446,28 @@ TEXT ·mod_shift63(SB), 7, $0-16
 	// ------------------------------------------------------------
 
 #define MOD_SHIFT_64_TO_95(shift, t0, t1, x0, x1, neg1, rzero) \
-	/* xhigh = x1, LSR #96 - shift */ ;                                            \
-	/* xmid = (x1, LSL #shift - 64) OR (x0, LSR #96 - shift) */ ;                  \
-	/* xlow  = x0, LSL #shift - 64 */ ;                                            \
-	/* calculate (xlow, 0) - (0, xlow) */ ;                                        \
-	SUB.S    x0<<(shift-64), rzero, t0  /* 0 - xlow */ ;                           \
-	RSC      x0<<(shift-64), rzero, t1 /* xlow - 0 - carry, no carry possible */ ; \
-	/* calculate (xlow, -xlow) - (xhigh, xmid) */ ;                                \
-	MOVW     x0>>(96-shift), x0  /* x0 = xmid */ ;                                 \
-	ORR      x1<<(shift-64), x0, x0  ;                                             \
-	SUB.S    x0, t0, t0   /* t0 - xmid */ ;                                        \
-	SBC.S    x1>>(96-shift), t1, t1  /* t1 - xhigh */ ;                            \
-	SUB.CC.S neg1, t0, t0  ;                                                       \
-	SBC.CC   $0, t1, t1   ;                                                        \
+	/* xhigh = x1, LSR #96 - shift */ ;                                           \
+	/* xmid = (x1, LSL #shift - 64) OR (x0, LSR #96 - shift) */ ;                 \
+	/* xlow  = x0, LSL #shift - 64 */ ;                                           \
+	/* calculate (xlow, 0) - (0, xlow) */ ;                                       \
+	SUB.S    x0<<(shift-64), rzero, t0  /* 0 - xlow */;                           \
+	RSC      x0<<(shift-64), rzero, t1 /* xlow - 0 - carry, no carry possible */; \
+	/* calculate (xlow, -xlow) - (xhigh, xmid) */ ;                               \
+	MOVW     x0>>(96-shift), x0  /* x0 = xmid */;                                 \
+	ORR      x1<<(shift-64), x0, x0;                                              \
+	SUB.S    x0, t0, t0   /* t0 - xmid */;                                        \
+	SBC.S    x1>>(96-shift), t1, t1  /* t1 - xhigh */;                            \
+	SUB.CC.S neg1, t0, t0;                                                        \
+	SBC.CC   $0, t1, t1;                                                          \
 
 #define MOD_SHIFT_64_TO_95_PROC(shift) \
-	MOVW    $-1, R12 ;                                    \
-	MOVW    $0, R11 ;                                     \
-	MOVM.IB (R13), [R0, R1] ;                             \
-	MOD_SHIFT_64_TO_95(shift, R4, R5, R0, R1, R12, R11) ; \
-	MOVW    R4, ret+8(FP) ;                               \
-	MOVW    R5, ret+12(FP) ;                              \
-	RET     ;                                             \
+	MOVW    $-1, R12;                                    \
+	MOVW    $0, R11;                                     \
+	MOVM.IB (R13), [R0, R1];                             \
+	MOD_SHIFT_64_TO_95(shift, R4, R5, R0, R1, R12, R11) ;\
+	MOVW    R4, ret+8(FP);                               \
+	MOVW    R5, ret+12(FP);                              \
+	RET     ;                                            \
 
 TEXT ·mod_shift66(SB), 7, $0-16
 	MOD_SHIFT_64_TO_95_PROC(66)


### PR DESCRIPTION
Removes whitespace before semicolons, and makes semicolons always have a space before the next statement.

Proposal for #10.

Still inserts a space after `;` in comments. We really shouldn't touch them.