### PR TITLE
Fix line comments in macro definitions.

### DIFF
--- a/testdata/bytes.golden
+++ b/testdata/bytes.golden
@@ -9,3 +9,8 @@
 	MACRO; \
 	MACRO; \
 	NOP
+
+#define macromacromacro \
+	MACRO; \ // A comment
+	MACRO; \ // Another comment  with backslash:\
+	NOP

--- a/testdata/bytes.in
+++ b/testdata/bytes.in
@@ -9,3 +9,8 @@ BYTE /* don't touch;semicolon in my comments*/
 MACRO   ;  \
 	MACRO   ;\
 NOP
+
+#define macromacromacro \
+MACRO   ;  \ // A comment
+	MACRO   ;\  // Another comment  with backslash:\
+NOP


### PR DESCRIPTION
Line comments in macro definitions (supported from Go 1.5+) are now handled properly.

Fixes #14.