### PR TITLE
Print errors on separate lines

### DIFF
--- a/cmd/asmfmt/main.go
+++ b/cmd/asmfmt/main.go
@@ -40,7 +40,7 @@ var (
 )
 
 func report(err error) {
-	fmt.Fprint(os.Stderr, err)
+	fmt.Fprintln(os.Stderr, err)
 	errors++
 	if !*allErrors && errors >= 10 {
 		os.Exit(2)


### PR DESCRIPTION
Currently `asmfmt` prints them all together:

```
$ echo 'package foo' > x.go
$ echo -n -e '\x00' > a.out
$ echo '#include "textflag.h"' > x.s
$ asmfmt -l *
zero (0) byte in input. file is unlikely an assembler filepackage instruction found. Go files are not supported$ 
```