### PR TITLE
Fix crash on line comments that start with a star.

### DIFF
--- a/asmfmt.go
+++ b/asmfmt.go
@@ -74,12 +74,11 @@ func (f *fstate) addLine(b []byte) error {
 		}()
 		if strings.Contains(s, "*/") {
 			ends := strings.Index(s, "*/")
-			end := strings.TrimSpace(s[:ends])
-			if f.lastStar {
-				end = end + " */"
-			} else {
-				end = end + "*/"
+			end := s[:ends]
+			if strings.HasPrefix(strings.TrimSpace(s), "*") && f.lastStar {
+				end = strings.TrimSpace(end) + " "
 			}
+			end = end + "*/"
 			f.insideBlock = false
 			s = strings.TrimSpace(s[ends+2:])
 			if strings.HasSuffix(s, "\\") {

--- a/testdata/mod_math_amd64.golden
+++ b/testdata/mod_math_amd64.golden
@@ -1,7 +1,7 @@
 /*
 Quicker way of loading MOD_P ?
-MOVL    $-1, R8
-NEGQ    R8
+        MOVL    $-1, R8
+        NEGQ    R8
 */
 #define MOD_P 0xFFFFFFFF00000001
 

--- a/testdata/nested_comment.golden
+++ b/testdata/nested_comment.golden
@@ -5,14 +5,14 @@ TEXT ·FailsFormatting(SB), NOSPLIT, $0
 
 TEXT ·FailsFormatting(SB), NOSPLIT, $0
 /*
-RET // */
+        RET //*/
 
 TEXT ·FailsFormatting(SB), NOSPLIT, $0
 	RET // Some longer comment*/
 
 TEXT ·FailsFormatting(SB), NOSPLIT, $0
 /*
-RET // Some longer comment */
+        RET // Some longer comment*/
 
 TEXT ·FailsFormatting(SB), NOSPLIT, $0
 	/*        RET // */

--- a/testdata/nested_comment.golden
+++ b/testdata/nested_comment.golden
@@ -1,0 +1,28 @@
+#include "textflag.h"
+
+TEXT ·FailsFormatting(SB), NOSPLIT, $0
+	RET // */
+
+TEXT ·FailsFormatting(SB), NOSPLIT, $0
+/*
+RET // */
+
+TEXT ·FailsFormatting(SB), NOSPLIT, $0
+	RET // Some longer comment*/
+
+TEXT ·FailsFormatting(SB), NOSPLIT, $0
+/*
+RET // Some longer comment */
+
+TEXT ·FailsFormatting(SB), NOSPLIT, $0
+	/*        RET // */
+
+/*
+	TESTL	BX, BX
+	JEQ	move_0
+	CMPL	BX, $2
+	JBE	move_1or2
+	CMPL	BX, $4
+	JBE	move_3or4
+	CMPL	BX, $8
+*/

--- a/testdata/nested_comment.in
+++ b/testdata/nested_comment.in
@@ -1,0 +1,30 @@
+#include "textflag.h"
+
+TEXT ·FailsFormatting(SB), NOSPLIT, $0
+        RET //*/
+
+
+TEXT ·FailsFormatting(SB), NOSPLIT, $0
+/*
+        RET //*/
+
+TEXT ·FailsFormatting(SB), NOSPLIT, $0
+        RET // Some longer comment*/
+
+
+TEXT ·FailsFormatting(SB), NOSPLIT, $0
+/*
+        RET // Some longer comment*/
+
+TEXT ·FailsFormatting(SB), NOSPLIT, $0
+/*        RET //*/
+
+/*
+	TESTL	BX, BX
+	JEQ	move_0
+	CMPL	BX, $2
+	JBE	move_1or2
+	CMPL	BX, $4
+	JBE	move_3or4
+	CMPL	BX, $8
+*/


### PR DESCRIPTION
Don't change indentation on block comments unless they start with a star.

Fixes #27