### PR TITLE
Don't indent comments before non-indented instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Using `gofmt -w mypackage` will Gofmt your Go files and format all assembler fil
 
 # updates
 
+* Aug 8, 2016: Don't indent comments before non-indented instruction.
 * Jun 10, 2016: Fixed crash with end-of-line comments that contained an end-of-block `/*` part.
 * Apr 14, 2016: Fix end of multiline comments in macro definitions.
 * Apr 14, 2016: Updated tools to Go 1.5+

--- a/asmfmt.go
+++ b/asmfmt.go
@@ -252,7 +252,6 @@ exitcomm:
 	// Should this line be at level 0?
 	if st.level0() && !(st.continued && f.lastContinued) {
 		if st.isTEXT() && len(f.queued) == 0 && len(f.comments) > 0 {
-			//f.out.WriteString(fmt.Sprintf("// len: %d\n", len(f.comments)))
 			f.indentation = 0
 		}
 		f.flush()

--- a/asmfmt.go
+++ b/asmfmt.go
@@ -62,6 +62,10 @@ type statement struct {
 }
 
 // Add a new input line.
+// Since you are looking at ths code:
+// This code has grown over a considerable amount of time,
+// and deserves a rewrite with proper parsing instead of this hodgepodge.
+// Its output is stable, and could be used as reference for a rewrite.
 func (f *fstate) addLine(b []byte) error {
 	if bytes.Contains(b, []byte{0}) {
 		return fmt.Errorf("zero (0) byte in input. file is unlikely an assembler file")
@@ -116,9 +120,13 @@ func (f *fstate) addLine(b []byte) error {
 		}()
 
 		s = strings.TrimPrefix(s, "//")
-
-		f.flush()
-		f.newLine()
+		if len(f.queued) > 0 {
+			f.flush()
+		}
+		// Newline before comments
+		if len(f.comments) == 0 {
+			f.newLine()
+		}
 
 		// Preserve whitespace if the first character after the comment
 		// is a whitespace
@@ -243,6 +251,10 @@ exitcomm:
 
 	// Should this line be at level 0?
 	if st.level0() && !(st.continued && f.lastContinued) {
+		if st.isTEXT() && len(f.queued) == 0 && len(f.comments) > 0 {
+			//f.out.WriteString(fmt.Sprintf("// len: %d\n", len(f.comments)))
+			f.indentation = 0
+		}
 		f.flush()
 
 		// Add newline before jump target.
@@ -534,7 +546,7 @@ func (st *statement) cleanParams() {
 // Comments and line-continuation (\) are aligned with spaces.
 func formatStatements(s []statement) []string {
 	res := make([]string, len(s))
-	maxParam := 0 // Lenght of longest parameter
+	maxParam := 0 // Length of longest parameter
 	maxInstr := 0 // Length of longest instruction WITH parameters.
 	maxAlone := 0 // Length of longest instruction without parameters.
 	for i, x := range s {

--- a/testdata/indent.golden
+++ b/testdata/indent.golden
@@ -9,3 +9,19 @@ TEXT ·crc32sse(SB), 7, $0
 	RET // RET is a terminator
 
 // This comment is at level 0, because it is following a terminator
+
+TEXT ·addVV(SB), NOSPLIT, $0
+	BR ·addVV_g(SB)
+
+// func subVV(z, x, y []Word) (c Word)
+// z[i] = x[i] - y[i] for all i, carrying
+TEXT ·subVV(SB), NOSPLIT, $0
+	MOVD z_len+8(FP), R7
+	MOVD x+24(FP), R8
+
+// func subVV(z, x, y []Word) (c Word)
+// z[i] = x[i] - y[i] for all i, carrying
+TEXT ·subVV(SB), NOSPLIT, $0
+	// func subVV(z, x, y []Word) (c Word)
+	MOVD z_len+8(FP), R7
+	MOVD x+24(FP), R8

--- a/testdata/indent.in
+++ b/testdata/indent.in
@@ -9,3 +9,19 @@ TEXT ·crc32sse(SB), 7, $0
 	RET// RET is a terminator
 
 	// This comment is at level 0, because it is following a terminator
+
+
+ TEXT ·addVV(SB), NOSPLIT, $0
+        BR ·addVV_g(SB)
+
+// func subVV(z, x, y []Word) (c Word)
+// z[i] = x[i] - y[i] for all i, carrying
+ TEXT ·subVV(SB), NOSPLIT, $0
+        MOVD z_len+8(FP), R7
+        MOVD x+24(FP), R8
+// func subVV(z, x, y []Word) (c Word)
+// z[i] = x[i] - y[i] for all i, carrying
+ TEXT ·subVV(SB), NOSPLIT, $0
+// func subVV(z, x, y []Word) (c Word)
+        MOVD z_len+8(FP), R7
+        MOVD x+24(FP), R8


### PR DESCRIPTION
Fixes #29.