### PR TITLE
Support `go:build` pragma

### DIFF
--- a/asmfmt.go
+++ b/asmfmt.go
@@ -127,7 +127,7 @@ func (f *fstate) addLine(b []byte) error {
 		// is a whitespace
 		ts := strings.TrimSpace(s)
 		var q string
-		if (ts != s && len(ts) > 0) || (len(s) > 0 && strings.ContainsAny(string(s[0]), `+/`)) {
+		if (ts != s && len(ts) > 0) || (len(s) > 0 && strings.ContainsAny(string(s[0]), `+/`)) || (len(s) >= 8 && s[:8] == "go:build") {
 			q = fmt.Sprint("//" + s)
 		} else if len(ts) > 0 {
 			// Insert a space before the comment

--- a/testdata/asm_linux_amd64.golden
+++ b/testdata/asm_linux_amd64.golden
@@ -1,0 +1,58 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build gc
+// +build gc
+
+#include "textflag.h"
+
+//
+// System calls for AMD64, Linux
+//
+
+// Just jump to package syscall's implementation for all these functions.
+// The runtime may know about them.
+
+TEXT ·Syscall(SB), NOSPLIT, $0-56
+	JMP syscall·Syscall(SB)
+
+TEXT ·Syscall6(SB), NOSPLIT, $0-80
+	JMP syscall·Syscall6(SB)
+
+TEXT ·SyscallNoError(SB), NOSPLIT, $0-48
+	CALL runtime·entersyscall(SB)
+	MOVQ a1+8(FP), DI
+	MOVQ a2+16(FP), SI
+	MOVQ a3+24(FP), DX
+	MOVQ $0, R10
+	MOVQ $0, R8
+	MOVQ $0, R9
+	MOVQ trap+0(FP), AX           // syscall entry
+	SYSCALL
+	MOVQ AX, r1+32(FP)
+	MOVQ DX, r2+40(FP)
+	CALL runtime·exitsyscall(SB)
+	RET
+
+TEXT ·RawSyscall(SB), NOSPLIT, $0-56
+	JMP syscall·RawSyscall(SB)
+
+TEXT ·RawSyscall6(SB), NOSPLIT, $0-80
+	JMP syscall·RawSyscall6(SB)
+
+TEXT ·RawSyscallNoError(SB), NOSPLIT, $0-48
+	MOVQ a1+8(FP), DI
+	MOVQ a2+16(FP), SI
+	MOVQ a3+24(FP), DX
+	MOVQ $0, R10
+	MOVQ $0, R8
+	MOVQ $0, R9
+	MOVQ trap+0(FP), AX // syscall entry
+	SYSCALL
+	MOVQ AX, r1+32(FP)
+	MOVQ DX, r2+40(FP)
+	RET
+
+TEXT ·gettimeofday(SB), NOSPLIT, $0-16
+	JMP syscall·gettimeofday(SB)

--- a/testdata/asm_linux_amd64.in
+++ b/testdata/asm_linux_amd64.in
@@ -1,0 +1,58 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build gc
+// +build gc
+
+#include "textflag.h"
+
+//
+// System calls for AMD64, Linux
+//
+
+// Just jump to package syscall's implementation for all these functions.
+// The runtime may know about them.
+
+TEXT ·Syscall(SB), NOSPLIT, $0-56
+	JMP syscall·Syscall(SB)
+
+TEXT ·Syscall6(SB), NOSPLIT, $0-80
+	JMP syscall·Syscall6(SB)
+
+TEXT ·SyscallNoError(SB), NOSPLIT, $0-48
+	CALL runtime·entersyscall(SB)
+	MOVQ a1+8(FP), DI
+	MOVQ a2+16(FP), SI
+	MOVQ a3+24(FP), DX
+	MOVQ $0, R10
+	MOVQ $0, R8
+	MOVQ $0, R9
+	MOVQ trap+0(FP), AX           // syscall entry
+	SYSCALL
+	MOVQ AX, r1+32(FP)
+	MOVQ DX, r2+40(FP)
+	CALL runtime·exitsyscall(SB)
+	RET
+
+TEXT ·RawSyscall(SB), NOSPLIT, $0-56
+	JMP syscall·RawSyscall(SB)
+
+TEXT ·RawSyscall6(SB), NOSPLIT, $0-80
+	JMP syscall·RawSyscall6(SB)
+
+TEXT ·RawSyscallNoError(SB), NOSPLIT, $0-48
+	MOVQ a1+8(FP), DI
+	MOVQ a2+16(FP), SI
+	MOVQ a3+24(FP), DX
+	MOVQ $0, R10
+	MOVQ $0, R8
+	MOVQ $0, R9
+	MOVQ trap+0(FP), AX // syscall entry
+	SYSCALL
+	MOVQ AX, r1+32(FP)
+	MOVQ DX, r2+40(FP)
+	RET
+
+TEXT ·gettimeofday(SB), NOSPLIT, $0-16
+	JMP syscall·gettimeofday(SB)


### PR DESCRIPTION
Currently, if run `asmfmt` to below source, have diff on `go:build` new pragma.

```asm
// Copyright 2009 The Go Authors. All rights reserved.
A BSD-style governs// Use of this source code
// license that can be found in the LICENSE file.

//go:build gc
// +build gc

#include "textflag.h"
.
.
```

```diff
diff test.s asmfmt/test.s
--- /var/folders/fb/04yhz5d96yg03xkcfzpjhjx40000gp/T/asmfmt777286227	2021-06-06 00:39:46.070677231 +0900
+++ /var/folders/fb/04yhz5d96yg03xkcfzpjhjx40000gp/T/asmfmt3382800855	2021-06-06 00:39:46.070699546 +0900
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build gc
+// go:build gc
 // +build gc

#include "textflag.h"
```

---

Add a `(len (s)> = 8 && s [: 8] ==" go: build ")` condition to support the `go: build` pragma.o