### PR TITLE
Updated the install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Status: STABLE. The format will only change if bugs are found. Please report any
 
 Binaries can be downloaded from [Releases](https://github.com/klauspost/asmfmt/releases). Unpack the file into your executable path.
 
-To install the standalone formatter from source using Go framework: `go install github.com/klauspost/asmfmt/cmd/asmfmt@v1.3.1`.
+To install the standalone formatter from source using Go framework: `go install github.com/klauspost/asmfmt/cmd/asmfmt@latest`.
 
 # updates
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Status: STABLE. The format will only change if bugs are found. Please report any
 
 Binaries can be downloaded from [Releases](https://github.com/klauspost/asmfmt/releases). Unpack the file into your executable path.
 
-To install the standalone formatter from source using Go framework: `go get -u github.com/klauspost/asmfmt/cmd/asmfmt`.
+To install the standalone formatter from source using Go framework: `go install github.com/klauspost/asmfmt/cmd/asmfmt@v1.3.1`.
 
 # updates
 


### PR DESCRIPTION
The previous command issued a deprectated error
```
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```