### PR TITLE
Detect when in a string literal

### DIFF
--- a/testdata/quoting.golden
+++ b/testdata/quoting.golden
@@ -1,0 +1,7 @@
+db ","
+db ";"
+db "http://example.com"
+db "2 strings", "http://example.com"
+db "3 strings", "2//slash groups", "http://example.com"
+db ','
+db ';'

--- a/testdata/quoting.in
+++ b/testdata/quoting.in
@@ -1,0 +1,7 @@
+db ","
+db ";"
+db "http://example.com"
+db "2 strings", "http://example.com"
+db "3 strings", "2//slash groups", "http://example.com"
+db ','
+db ';'


### PR DESCRIPTION
This PR detects when you are within a string or character literal to avoid adding spaces around `,`, `;`, and `//` markers.

Fixes #46 